### PR TITLE
Use sendBefore callback before uploading minidump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sentry/electron",
+  "name": "@tandemchat/sentry-electron",
   "description": "Offical Sentry SDK for Electron",
   "version": "1.3.0",
   "main": "./dist/index.js",

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -206,7 +206,7 @@ export class MainBackend extends BaseBackend<ElectronOptions> implements CommonB
     const reporter: CrashReporterExt = crashReporter as any;
     const crashesDirectory = reporter.getCrashesDirectory();
 
-    this._uploader = new MinidumpUploader(dsn, crashesDirectory, getCachePath());
+    this._uploader = new MinidumpUploader(dsn, crashesDirectory, getCachePath(), this._options.beforeSend);
 
     // Flush already cached minidumps from the queue.
     forget(this._uploader.flushQueue());


### PR DESCRIPTION
# Description
- Created a new package based on sentry-electron fork and these changes [here](https://www.npmjs.com/settings/tandemchat/packages) 
- Call ```sendBefore``` callback before sending minidump (same as with electron js errors). If ```sendBefore``` returns null, the crash report will be deleted and not sent to sentry. 
- Lowered crash report max-age to 10 days instead of 30 (given frequency of tandem updates, 30 days log might be unusable). 